### PR TITLE
Revert "ci: fix annotation for GHCR"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,8 +48,6 @@ jobs:
 
     - uses: docker/metadata-action@v5
       id: meta
-      env:
-        DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
       with:
         images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
         tags: |


### PR DESCRIPTION
This reverts commit 3f97e91e2be5536c740cc92bb0e6bc97aa6be1f8.

`ERROR: failed to solve: index annotations not supported for single platform export`