### PR TITLE
use ElParking docker-compose-action for supporting the v2 docker compose api

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,7 @@ jobs:
         provenance: false
 
     - name: Test run Docker Compose
-      uses: adambirds/docker-compose-action@v1.3.0
+      uses: ElParking/docker-compose-action@1.4.5
       id: test
       with:
         compose-file: .github/test/docker-compose.yml
@@ -86,10 +86,13 @@ jobs:
 
     - name: Print Docker Compose logs
       if: always() && (steps.test.outcome == 'failure')
+      env:
+        IMAGE: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
+        IMAGE_PLATFORM: ${{ matrix.platform }}
       run: |
         cd .github/test
-        docker-compose ps -a
-        docker compose logs
+        docker compose ps -a
+        docker compose logs -t --tail=all
 
     - name: Export image digest
       run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,10 +54,11 @@ RUN \
 COPY configs/ /
 
 EXPOSE 80
-HEALTHCHECK CMD [ "/healthcheck.sh" ] \
+HEALTHCHECK \
   --interval=20s \
   --timeout=10s \
   --start-period=60s \
-  --retries=5
+  --retries=5 \
+  CMD [ "/healthcheck.sh" ]
 
 ENTRYPOINT ["/entry.sh"]


### PR DESCRIPTION
Github has removed the v1 docker-compose from hosted runners: https://github.com/actions/runner-images/issues/9557

The replacement docker-compose-action supports v2 properly, and the remaining changes are needed to make everything work with docker compose.

The trickiest bit is the healthcheck command - the original order was seemingly never officially supported, but now definitely breaks with docker 26.