### PR TITLE
django3 only supports psycopg2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ celery==5.4.0
 django-environ==0.11.2
 gunicorn==22.0.0
 mysqlclient==2.2.4
-psycopg[binary]==3.2.1
+psycopg2-binary==2.9.9
 redis==5.0.7
 whitenoise==6.7.0


### PR DESCRIPTION
sadly patchman is not yet on a django release that works with psycopg3, so this is needed to make database connections to postgres possible